### PR TITLE
Fix c/ and c? actions

### DIFF
--- a/plugin/slasher.vim
+++ b/plugin/slasher.vim
@@ -25,7 +25,7 @@
 set shm+=s
 
 function! slasher#wrap(seq)
-  if mode() == 'c' && stridx('/?', getcmdtype()) < 0
+  if mode() == 'c'
     return a:seq
   endif
   silent! autocmd! slash
@@ -33,7 +33,7 @@ function! slasher#wrap(seq)
 endfunction
 
 function! slasher#immobile_wrap(seq)
-  if mode() == 'c' && stridx('/?', getcmdtype()) < 0
+  if mode() == 'c'
     return a:seq
   endif
   silent! autocmd! slash


### PR DESCRIPTION
`c/foo<cr>` or `c?bar<cr>` inserts the literal string `<plug>(slash-trailer-without-move)` at the cursor.

Edit: this is reproducible with Vim 7.4, Vim 8.1, Vim 9.0, Neovim 0.4.4 and Neovim 0.7.2, so I guess it's not a compatibility problem.